### PR TITLE
Add macro commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -448,9 +448,14 @@ macros_group = discord_command.Group(
 )
 @discord_command.checks.has_any_role(*ROLES_USE_MACROS)
 async def create(interaction: discord.Interaction, name: str):
-    await interaction.response.send_modal(
-        MacroCreate(macro_name=name, macros_db=bot_utils.macros_db)
-    )
+    if get_macro(bot_utils.macros_db, name) is None:
+        await interaction.response.send_modal(
+            MacroCreate(macro_name=name, macros_db=bot_utils.macros_db)
+        )
+    else:
+        await interaction.response.send_message(
+            f"Macro with name `{name}` already exists!", ephemeral=True
+        )
 
 
 @macros_group.command(

--- a/enums/command.py
+++ b/enums/command.py
@@ -11,10 +11,11 @@ class Command(StrEnum):
     HELP = "help"
     TESTER_COVERAGE = "testers-coverage"
     MACROS = "macros"
-    MACROS_CREATE = "macros create"
-    MACROS_EDIT = "macros edit"
-    MACROS_SHOW = "macros show"
-    MACROS_DELETE = "macros delete"
+    MACROS_CREATE = "create"
+    MACROS_EDIT = "edit"
+    MACROS_SHOW = "show"
+    MACROS_LIST = "list"
+    MACROS_DELETE = "delete"
 
     def description(self) -> str:
         return {
@@ -30,5 +31,6 @@ class Command(StrEnum):
             self.MACROS_CREATE: "Creates a new macro. Moderator only.",
             self.MACROS_EDIT: "Edits an existing macro. Moderator only.",
             self.MACROS_SHOW: "Shows a macro, and optionally mentions someone. Moderator only.",
+            self.MACROS_LIST: "Lists all created macros. Moderator only.",
             self.MACROS_DELETE: "Deletes a macro. Moderator only.",
         }[self]

--- a/enums/command.py
+++ b/enums/command.py
@@ -10,6 +10,11 @@ class Command(StrEnum):
     LOGS = "logs"
     HELP = "help"
     TESTER_COVERAGE = "testers-coverage"
+    MACROS = "macros"
+    MACROS_CREATE = "macros create"
+    MACROS_EDIT = "macros edit"
+    MACROS_SHOW = "macros show"
+    MACROS_DELETE = "macros delete"
 
     def description(self) -> str:
         return {
@@ -21,4 +26,9 @@ class Command(StrEnum):
             self.LOGS: "Tells you where the Music Presence logs are located",
             self.HELP: "Use this command if you need help with Music Presence",
             self.TESTER_COVERAGE: "Report the OS coverage among beta testers.",
+            self.MACROS: "Create, edit, and delete macros to be reused in troubleshooting. Moderator only.",
+            self.MACROS_CREATE: "Creates a new macro. Moderator only.",
+            self.MACROS_EDIT: "Edits an existing macro. Moderator only.",
+            self.MACROS_SHOW: "Shows a macro, and optionally mentions someone. Moderator only.",
+            self.MACROS_DELETE: "Deletes a macro. Moderator only.",
         }[self]

--- a/enums/constants.py
+++ b/enums/constants.py
@@ -8,6 +8,7 @@ MIN_RETENTION_UPDATE_INTERVAL = 60 * 60 * 24  # 24 hours (in seconds)
 
 ROLE_BETA_TESTER = 1349699182968967219
 ROLES_OS = [1295480990722035752, 1295480950242676737, 1295480841987821628]
+ROLES_USE_MACROS = ["Moderator"]
 
 HELP_URL_INSTALL = "https://github.com/ungive/discord-music-presence/blob/master/documentation/installation-instructions.md"
 HELP_URL_TROUBLESHOOTING = "https://github.com/ungive/discord-music-presence/blob/master/documentation/troubleshooting.md"

--- a/objects/macro_creator_modal.py
+++ b/objects/macro_creator_modal.py
@@ -34,7 +34,7 @@ class MacroModal(ui.Modal):
         label="Image URL (optional)", style=discord.TextStyle.short, required=False
     )
     macro_color = ui.TextInput(
-        label="Embed Color (optional, hex code)",
+        label="Embed Color (optional, hex code starting with #)",
         style=discord.TextStyle.short,
         required=False,
     )

--- a/objects/macro_creator_modal.py
+++ b/objects/macro_creator_modal.py
@@ -1,0 +1,126 @@
+import sqlite3
+import discord
+from collections.abc import Callable
+from discord import ui
+
+from objects.macros import Macro
+from objects.macro_embed import MacroEmbed
+from utils.macros_database import add_macro, edit_macro
+
+
+class ConfirmationView(ui.View):
+    def __init__(self):
+        super().__init__()
+        self.value = None
+
+    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.green)
+    async def confirm(self, _: discord.Interaction, __: discord.ui.Button):
+        self.value = True
+        self.stop()
+
+    # This one is similar to the confirmation button except sets the inner value to `False`
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.grey)
+    async def cancel(self, _: discord.Interaction, __: discord.ui.Button):
+        self.value = False
+        self.stop()
+
+
+class MacroModal(ui.Modal):
+    macro_title = ui.TextInput(label="Title", style=discord.TextStyle.short)
+    macro_description = ui.TextInput(
+        label="Contents", style=discord.TextStyle.paragraph
+    )
+    macro_image_url = ui.TextInput(
+        label="Image URL (optional)", style=discord.TextStyle.short, required=False
+    )
+    macro_color = ui.TextInput(
+        label="Embed Color (optional, hex code)",
+        style=discord.TextStyle.short,
+        required=False,
+    )
+
+    def __init__(
+        self, modal_title: str, macros_db: sqlite3.Connection, macro: Macro = None
+    ):
+        super().__init__(title=modal_title)
+        self.macros_db = macros_db
+        self.macro = macro
+
+    async def on_submit(
+        self,
+        interaction: discord.Interaction,
+        db_callback: Callable[[sqlite3.Connection, Macro], int],
+        prompt_msg: str,
+        confirm_msg: str,
+        cancel_msg: str,
+    ):
+
+        embed = MacroEmbed(self.macro).show_embed()
+        buttons = ConfirmationView()
+
+        if self.macro.image_url:
+            embed.set_image(url=self.macro.image_url)
+
+        await interaction.response.send_message(
+            prompt_msg,
+            embed=embed,
+            view=buttons,
+            ephemeral=True,
+        )
+        await buttons.wait()
+
+        if buttons.value:
+            db_callback(self.macros_db, self.macro)
+            await interaction.edit_original_response(content=confirm_msg, view=None)
+        else:
+            await interaction.edit_original_response(
+                content=cancel_msg, embed=None, view=None
+            )
+
+
+class MacroCreate(MacroModal):
+    def __init__(self, macro_name: str, macros_db: sqlite3.Connection):
+        self.macro_name = macro_name
+        super().__init__(f"Creating macro: {macro_name}", macros_db)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        self.macro = Macro.from_create_interaction(
+            name=self.macro_name,
+            title=self.macro_title.value,
+            description=self.macro_description.value,
+            ctx=interaction,
+            color=self.macro_color.value,
+            image_url=self.macro_image_url.value,
+        )
+
+        return await super().on_submit(
+            interaction,
+            db_callback=add_macro,
+            prompt_msg=f"Is this okay for macro `{self.macro.name}`?",
+            confirm_msg=f"Macro `{self.macro.name}` added.",
+            cancel_msg="Macro creation cancelled.",
+        )
+
+
+class MacroEdit(MacroModal):
+    def __init__(self, macro: Macro, macros_db: sqlite3.Connection):
+        super().__init__(f"Editing macro: {macro.name}", macros_db, macro)
+
+        self.macro_title.default = self.macro.title
+        self.macro_description.default = self.macro.description
+        self.macro_color.default = self.macro.embed_color
+        self.macro_image_url.default = self.macro.image_url
+
+    async def on_submit(self, interaction: discord.Interaction):
+        self.macro.title = self.macro_title.value
+        self.macro.description = self.macro_description.value
+        self.macro.image_url = self.macro_image_url.value
+        self.macro.embed_color = self.macro_color.value
+
+        return await super().on_submit(
+            interaction,
+            db_callback=edit_macro,
+            prompt_msg=f"Is this okay for macro `{self.macro.name}`?",
+            confirm_msg=f"Macro `{self.macro.name}` edited.",
+            cancel_msg="Macro edit cancelled.",
+        )

--- a/objects/macro_embed.py
+++ b/objects/macro_embed.py
@@ -10,6 +10,7 @@ class MacroEmbed:
         )
         self.macro = macro
 
+    # This is a function because you cannot add images to the end of an embed regularly
     def show_embed(self) -> discord.Embed:
         embed = discord.Embed(
             title=self.macro.title, description=self.macro.description, color=self.color

--- a/objects/macro_embed.py
+++ b/objects/macro_embed.py
@@ -1,0 +1,21 @@
+import discord
+
+from objects.macros import Macro
+
+
+class MacroEmbed:
+    def __init__(self, macro: Macro):
+        self.color = discord.Color.from_str(
+            macro.embed_color if macro.embed_color else "#34353B"
+        )
+        self.macro = macro
+
+    def show_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=self.macro.title, description=self.macro.description, color=self.color
+        )
+
+        if self.macro.image_url:
+            embed.set_image(url=self.macro.image_url)
+
+        return embed

--- a/objects/macros.py
+++ b/objects/macros.py
@@ -1,0 +1,50 @@
+from datetime import timezone
+import discord
+
+
+class Macro:
+    """
+    A representation of a column in the `macros` table.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        title: str,
+        description: str,
+        creator: int,
+        date_created: float,
+        date_edited: float = None,
+        image_url: str = None,
+        embed_color: str = None,
+    ):
+        self.name = name
+        self.title = title
+        self.description = description
+        self.creator = creator
+        self.date_created = date_created
+        self.date_edited = date_created if date_edited is None else date_edited
+        self.image_url = image_url
+        self.embed_color = embed_color
+
+    @classmethod
+    def from_create_interaction(
+        cls,
+        name: str,
+        title: str,
+        description: str,
+        ctx: discord.Interaction,
+        color: str | None = None,
+        image_url: str | None = None,
+    ):
+        created_time = ctx.created_at.replace(tzinfo=timezone.utc).timestamp()
+
+        return cls(
+            name,
+            title,
+            description,
+            ctx.user.id,
+            created_time,
+            image_url=image_url,
+            embed_color=color,
+        )

--- a/utils/bot_utils.py
+++ b/utils/bot_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sqlite3
 import aiohttp
 import pickledb
 import discord
@@ -34,9 +35,11 @@ class BotUtils:
     def __init__(
         self,
         client: discord.Client,
+        macros_db: sqlite3.Connection,
         settings: pickledb.PickleDB,
         tree: discord.app_commands.CommandTree,
     ):
+        self.macros_db = macros_db
         self.client = client
         self.settings = settings
         self.tree = tree

--- a/utils/init_database.py
+++ b/utils/init_database.py
@@ -1,10 +1,36 @@
 import pickledb
+import sqlite3
 
 
-def load_database(version: int = 0) -> pickledb.PickleDB:
+def load_settings_database(version: int = 0) -> pickledb.PickleDB:
     settings = pickledb.load(f"settings.{version}.db", True)
     for key in ["apps", "user_apps", "roles"]:
         if not settings.exists(key):
             settings.dcreate(key)
 
     return settings
+
+
+def load_macros_database(db_file: str):
+    conn = sqlite3.connect(db_file)
+
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+    CREATE TABLE IF NOT EXISTS macros(
+        name TEXT PRIMARY KEY NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL,
+        creator INTEGER NOT NULL,
+        date_created REAL NOT NULL,
+        date_edited REAL NOT NULL,
+        image_url TEXT,
+        embed_color TEXT
+    )
+    """
+    )
+
+    conn.commit()
+
+    return conn

--- a/utils/macros_database.py
+++ b/utils/macros_database.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+import sqlite3
+
+from objects.macros import Macro
+
+
+def add_macro(conn: sqlite3.Connection, macro: Macro) -> int:
+    cur = conn.cursor()
+
+    res = cur.execute(
+        "INSERT INTO macros VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            macro.name,
+            macro.title,
+            macro.description,
+            macro.creator,
+            macro.date_created,
+            macro.date_edited,
+            macro.image_url,
+            macro.embed_color,
+        ),
+    )
+
+    conn.commit()
+    return res.rowcount
+
+
+def edit_macro(conn: sqlite3.Connection, macro: Macro) -> int:
+    cur = conn.cursor()
+    macro.date_edited = datetime.now(tz=timezone.utc).timestamp()
+
+    res = cur.execute(
+        "UPDATE macros SET title=?, description=?, image_url=?, embed_color=?, date_edited=? WHERE name=?",
+        (
+            macro.title,
+            macro.description,
+            macro.image_url,
+            macro.embed_color,
+            macro.date_edited,
+            macro.name,
+        ),
+    )
+
+    conn.commit()
+    return res.rowcount
+
+
+def delete_macro(conn: sqlite3.Connection, name: str) -> int:
+    cur = conn.cursor()
+
+    res = cur.execute("DELETE FROM macros WHERE name=?", (name,))
+
+    conn.commit()
+    return res.rowcount
+
+
+def get_macro(conn: sqlite3.Connection, name: str) -> Macro | None:
+    cur = conn.cursor()
+
+    res = cur.execute("SELECT * FROM macros WHERE name=?", (name,))
+
+    macro_tuple = res.fetchone()
+    return Macro(*macro_tuple) if macro_tuple is not None else None
+
+
+def macro_names(conn: sqlite3.Connection) -> tuple | None:
+    cur = conn.cursor()
+
+    res = cur.execute("SELECT name FROM macros ORDER BY date_edited DESC LIMIT 25")
+    return res.fetchall()
+
+
+def macro_search(conn: sqlite3.Connection, name: str) -> tuple | None:
+    cur = conn.cursor()
+
+    res = cur.execute(
+        "SELECT name FROM macros WHERE name LIKE ? ORDER BY date_edited DESC LIMIT 25",
+        (f"%{name}%",),
+    )
+    return res.fetchall()

--- a/utils/macros_database.py
+++ b/utils/macros_database.py
@@ -70,6 +70,17 @@ def macro_names(conn: sqlite3.Connection) -> tuple | None:
     return res.fetchall()
 
 
+def macros_list(conn: sqlite3.Connection) -> tuple | None:
+    cur = conn.cursor()
+
+    res = cur.execute("SELECT * FROM macros")
+
+    macros = res.fetchall()
+    return (
+        [Macro(*macro_tuple) for macro_tuple in macros] if macros is not None else None
+    )
+
+
 def macro_search(conn: sqlite3.Connection, name: str) -> tuple | None:
     cur = conn.cursor()
 


### PR DESCRIPTION
Closes #7.

Adds a group of commands with the prefix `macros`:

- `/macros create` (`name`: string): Opens a modal which lets you create an embed. Lets you preview the macro before it's saved.

![The macro creation modal.](https://github.com/user-attachments/assets/125f1a33-7308-44aa-99ee-98c4236aa7c1)
![The preview of the created macro.](https://github.com/user-attachments/assets/641b4df2-c2ee-4513-83c3-70435e3ce396)

- `/macros edit` (`name`: string): The same as `/macros create`, but lets you edit an existing macro.
- `/macros show` (`name`: string, `mention`: (optional) Discord user): Lets you send a macro, and optionally, mention a user.

![Showing a macro](https://github.com/user-attachments/assets/c9cbcfa9-7d34-4be8-be82-df297e65ffd7)

- `/macros list`: Lists all created macros.
- `/macros delete` (`name`: string): Deletes a macro. 

There are probably a few edge cases I forgot, so please test this carefully before merging!

