### PR TITLE
Fix macros... again

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -24,8 +24,6 @@ from utils.init_database import load_macros_database, load_settings_database
 from utils.macros_database import (
     delete_macro,
     get_macro,
-    macro_names,
-    macro_search,
     macros_list,
 )
 
@@ -82,6 +80,7 @@ async def on_guild_remove(guild: discord.Guild):
 @client.event
 async def on_presence_update(_: discord.Member, member: discord.Member):
     await bot_utils.check_member(member)
+
 
 @client.event
 async def on_message(message: discord.Message):
@@ -302,7 +301,9 @@ async def command_joined_stats(
     await interaction.response.send_message(embed=embed)
 
 
-@tree.command(name=enums.Command.LISTENING, description=enums.Command.LISTENING.description())
+@tree.command(
+    name=enums.Command.LISTENING, description=enums.Command.LISTENING.description()
+)
 async def command_listening_role(
     interaction: discord.Interaction, delete: Optional[bool]
 ):
@@ -388,7 +389,9 @@ async def command_stop(interaction: discord.Interaction):
 async def command_logs(
     interaction: discord.Interaction, os: discord_command.Choice[str] = None
 ):
-    await bot_utils.logs_response_to_interaction(interaction, os.value if os is not None else None)
+    await bot_utils.logs_response_to_interaction(
+        interaction, os.value if os is not None else None
+    )
 
 
 @tree.command(name=enums.Command.HELP, description=enums.Command.HELP.description())
@@ -428,7 +431,10 @@ async def command_help(
     )
 
 
-@tree.command(name=enums.Command.TESTER_COVERAGE, description=enums.Command.TESTER_COVERAGE.description())
+@tree.command(
+    name=enums.Command.TESTER_COVERAGE,
+    description=enums.Command.TESTER_COVERAGE.description(),
+)
 async def command_tester_coverage(interaction: discord.Interaction):
     guild = interaction.guild
     beta_tester_role = guild.get_role(ROLE_BETA_TESTER)
@@ -511,7 +517,6 @@ async def edit(interaction: discord.Interaction, name: str):
     bot_utils.update_macros_cache()
 
 
-# Works for now, might be a problem in the future
 @macros_group.command(
     name=enums.Command.MACROS_LIST,
     description=enums.Command.MACROS_LIST.description(),
@@ -565,7 +570,7 @@ async def remove(interaction: discord.Interaction, name: str):
 @remove.autocomplete("name")
 @macro.autocomplete("name")
 async def macro_autocomplete(
-    interaction: discord.Interaction, current: str
+    _: discord.Interaction, current: str
 ) -> list[discord_command.Choice[str]]:
     if current is None or current == "":
         return [
@@ -574,7 +579,7 @@ async def macro_autocomplete(
         ][:25]
     else:
         return [
-            discord_command.Choice(name=macro_name[0], value=macro_name[0])
+            discord_command.Choice(name=macro_name, value=macro_name)
             for macro_name in bot_utils.search_macros(current)
         ]
 
@@ -582,21 +587,27 @@ async def macro_autocomplete(
 tree.add_command(macros_group)
 
 
-@tree.command(name=enums.Command.AUTOLOG, description=enums.Command.AUTOLOG.description())
+@tree.command(
+    name=enums.Command.AUTOLOG, description=enums.Command.AUTOLOG.description()
+)
 @discord_command.choices(
     state=[
         discord_command.Choice(name=enums.AutologState.ON, value=enums.AutologState.ON),
-        discord_command.Choice(name=enums.AutologState.OFF, value=enums.AutologState.OFF),
+        discord_command.Choice(
+            name=enums.AutologState.OFF, value=enums.AutologState.OFF
+        ),
     ]
 )
 async def command_autolog(
-        interaction: discord.Interaction,
-        channel: Optional[discord.TextChannel],
-        state: Optional[discord_command.Choice[str]]
+    interaction: discord.Interaction,
+    channel: Optional[discord.TextChannel],
+    state: Optional[discord_command.Choice[str]],
 ):
     global settings
 
-    state = enums.AutologState(state.value) if state is not None else enums.AutologState.ON
+    state = (
+        enums.AutologState(state.value) if state is not None else enums.AutologState.ON
+    )
 
     reply_message = bot_utils.autolog_command(channel, state)
     if reply_message is not None:

--- a/objects/log_request_matcher.py
+++ b/objects/log_request_matcher.py
@@ -1,5 +1,6 @@
 import re
 
+
 class LogRequestMatcher:
     RE_AUTOLOG = [
         r"^.*(send|share|show|need)[a-zA-Z0-9\s,]{1,16}\blogs?\b.*$",
@@ -8,4 +9,6 @@ class LogRequestMatcher:
     ]
 
     def test(self, message: str) -> bool:
-        return any(re.compile(regex, re.IGNORECASE).match(message) for regex in self.RE_AUTOLOG)
+        return any(
+            re.compile(regex, re.IGNORECASE).match(message) for regex in self.RE_AUTOLOG
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,4 @@ propcache==0.2.0
 py-memoize==3.1.1
 python-dotenv==1.0.1
 reactionmenu==3.1.7
-thefuzz==0.22.1
 yarl==1.15.5

--- a/tests/test_log_request_matcher.py
+++ b/tests/test_log_request_matcher.py
@@ -1,5 +1,6 @@
 from objects import LogRequestMatcher
 
+
 def test_log_request_patterns():
     matcher = LogRequestMatcher()
 

--- a/utils/bot_utils.py
+++ b/utils/bot_utils.py
@@ -7,9 +7,6 @@ import pickledb
 import discord
 import dataclasses
 
-import thefuzz
-import thefuzz.process
-
 import enums
 import objects
 
@@ -66,7 +63,9 @@ class BotUtils:
                 if listener_role is None:
                     # the role seems to have been deleted
                     del guild_roles[role_id]
-                    self.settings.dadd(enums.SettingsKeys.ROLES, (guild_id, guild_roles))
+                    self.settings.dadd(
+                        enums.SettingsKeys.ROLES, (guild_id, guild_roles)
+                    )
 
                 return listener_role
 
@@ -150,7 +149,9 @@ class BotUtils:
                         # Make sure it's not updated too frequently though
                         info.timestamp = now
                         user_apps[app_id_key] = dataclasses.asdict(info)
-                        self.settings.dadd(enums.SettingsKeys.USER_APPS, (str(member.id), user_apps))
+                        self.settings.dadd(
+                            enums.SettingsKeys.USER_APPS, (str(member.id), user_apps)
+                        )
                 return await self.give_role_listener(member)
 
         await self.clear_role_listeners_of_member(member)
@@ -286,9 +287,7 @@ class BotUtils:
 
         return embed
 
-    def logs_response(
-        self, platform: enums.Platform | None = None
-    ) -> str:
+    def logs_response(self, platform: enums.Platform | None = None) -> str:
         lines = ["You can find the log file for Music Presence"]
         if platform is None:
             lines[0] += " here:"
@@ -323,17 +322,23 @@ class BotUtils:
         self.macros_cache = [macro.name for macro in macros] if macros else []
 
     def search_macros(self, query: str):
-        return thefuzz.process.extract(query, self.macros_cache, limit=25)
+        return [macro_name for macro_name in self.macros_cache if query in macro_name]
 
     async def autolog(self, message: discord.Message):
-        is_channel_observed = self.settings.lexists(enums.SettingsKeys.AUTOLOG, f"{message.guild.id}:{message.channel.id}")
+        is_channel_observed = self.settings.lexists(
+            enums.SettingsKeys.AUTOLOG, f"{message.guild.id}:{message.channel.id}"
+        )
         if is_channel_observed and LogRequestMatcher().test(message.content):
             await message.reply(self.logs_response())
 
-    def autolog_command(self, channel: discord.TextChannel|None, state: enums.AutologState) -> str|None:
+    def autolog_command(
+        self, channel: discord.TextChannel | None, state: enums.AutologState
+    ) -> str | None:
         if channel is not None:
             channel_value = f"{channel.guild.id}:{channel.id}"
-            is_channel_observed = self.settings.lexists(enums.SettingsKeys.AUTOLOG, channel_value)
+            is_channel_observed = self.settings.lexists(
+                enums.SettingsKeys.AUTOLOG, channel_value
+            )
 
             if state is enums.AutologState.ON:
                 if not is_channel_observed:

--- a/utils/init_database.py
+++ b/utils/init_database.py
@@ -6,7 +6,11 @@ import enums
 def load_settings_database(version: int = 0) -> pickledb.PickleDB:
     settings = pickledb.load(f"settings.{version}.db", True)
 
-    for key in [enums.SettingsKeys.ROLES, enums.SettingsKeys.APPS, enums.SettingsKeys.USER_APPS]:
+    for key in [
+        enums.SettingsKeys.ROLES,
+        enums.SettingsKeys.APPS,
+        enums.SettingsKeys.USER_APPS,
+    ]:
         if not settings.exists(key):
             settings.dcreate(key)
 

--- a/utils/macros_database.py
+++ b/utils/macros_database.py
@@ -63,27 +63,10 @@ def get_macro(conn: sqlite3.Connection, name: str) -> Macro | None:
     return Macro(*macro_tuple) if macro_tuple else None
 
 
-def macro_names(conn: sqlite3.Connection) -> list | None:
-    cur = conn.cursor()
-
-    res = cur.execute("SELECT name FROM macros ORDER BY date_edited DESC LIMIT 25")
-    return res.fetchall()
-
-
 def macros_list(conn: sqlite3.Connection) -> list | None:
     cur = conn.cursor()
 
-    res = cur.execute("SELECT * FROM macros")
+    res = cur.execute("SELECT * FROM macros ORDER BY date_edited DESC")
 
     macros = res.fetchall()
     return [Macro(*macro_tuple) for macro_tuple in macros] if macros else None
-
-
-def macro_search(conn: sqlite3.Connection, name: str) -> list | None:
-    cur = conn.cursor()
-
-    res = cur.execute(
-        "SELECT name FROM macros WHERE name LIKE ? ORDER BY date_edited DESC LIMIT 25",
-        (f"%{name}%",),
-    )
-    return res.fetchall()


### PR DESCRIPTION
- The cache is now actually sorted by date edited, from latest to earliest. (The picture doesn't show me adding an extra `DESC` to the end of the query.)
![The query being changed so that the cache is actually sorted.](https://github.com/user-attachments/assets/8f36011b-ed3c-48d7-a54e-343a7beb1fee)
- Remove the need for fuzzy searching because all we really need to search is a simple "`phrase in macro_name`" conditional
- Replace the long message in `/macros list` with a paginated embed, courtesy of [`reactionmenu`](https://pypi.org/project/reactionmenu/)
  - I don't want to deal with pagination please understand
  - Interactions expire after 5 minutes
![A paginated embed showing a list of available macros.](https://github.com/user-attachments/assets/01f8c803-e185-4c33-9efd-d3a9a661b477)
